### PR TITLE
bug fix in buildSaveQuery 

### DIFF
--- a/lib/engines/MySQL.js
+++ b/lib/engines/MySQL.js
@@ -506,10 +506,10 @@ _.buildSaveQuery = function(struct, model, data, autoIDs) {
 
 			if (Array.isArray(data['id'])) {
 				var condStr = data['id'].join(', ');
-				query += sprintf(datArr.join(', ') + ' WHERE `id` IN (%s)', condStr);
+				query += datArr.join(', ') + sprintf(' WHERE `id` IN (%s)', condStr);
 			}
 			else
-				query += sprintf(datArr.join(', ') + ' WHERE `id`=%s', data['id']);
+				query += datArr.join(', ') + sprintf(' WHERE `id`= %s', data['id']);
 
 			return query;
 		} else {


### PR DESCRIPTION
simplified an argument to sprintf when calling buildSaveQuery in order to avoid an unintended pattern mismatch
